### PR TITLE
Using files for finding EFM state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "efm-api-node-state"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "BSD-2"
 description = "HTTP service and REST API exposing the state of the current EFM node"

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ changes on traffic routing.
 
 ## GET /primary
 
-Based on the execution of the EFM `node-status-json` command, this API call
-returns an HTTP response code set to `200` if the current node is the primary
-node of the EFM cluster.
+Based on the presence of a specific EFM trigger file, this API call returns
+an HTTP response code set to `200` if the current node is the primary node of
+the EFM cluster.
 
 Example:
 ```http
@@ -67,6 +67,19 @@ port = 9000
 shell = "/bin/sh"
 # DEBUG, INFO, WARN, ERROR
 log_level = "DEBUG"
+```
+
+## EFM configuration
+
+EFM configuration must be updated with the following properties:
+```
+script.load.balancer.attach=/bin/touch /var/run/efm-4.5/efm_trigger_%t
+script.load.balancer.detach=/bin/rm -f /var/run/efm-4.5/efm_trigger_%t
+script.custom.monitor=/usr/edb/efm-api-node-state/scripts/efm_monitor.sh 4.5
+custom.monitor.interval=5
+custom.monitor.timeout=10
+custom.monitor.safe.mode=true
+auto.resume.period=5
 ```
 
 ### Settings

--- a/packaging/rpm/efm-api-node-state.spec
+++ b/packaging/rpm/efm-api-node-state.spec
@@ -28,6 +28,7 @@ cargo build --release
 %{__install} /workspace/target/release/efm-api-node-state %{buildroot}/%{installpath}/bin/efm-api-node-state
 %{__install} /workspace/scripts/efm_check_primary.sh %{buildroot}/usr/edb/efm-api-node-state/scripts/efm_check_primary.sh
 %{__install} /workspace/scripts/efm_check_standby.sh %{buildroot}/usr/edb/efm-api-node-state/scripts/efm_check_standby.sh
+%{__install} /workspace/scripts/efm_monitoring.sh %{buildroot}/usr/edb/efm-api-node-state/scripts/efm_monitoring.sh
 %{__install} /workspace/config.toml %{buildroot}/etc/edb/efm-api-node-state/config.toml
 %{__install} /workspace/systemd/efm-api-node-state.service %{buildroot}/lib/systemd/system/efm-api-node-state.service
 
@@ -38,6 +39,7 @@ cargo build --release
 %attr(-, root, root) %{installpath}/bin/efm-api-node-state
 %attr(-, root, root) /usr/edb/efm-api-node-state/scripts/efm_check_primary.sh
 %attr(-, root, root) /usr/edb/efm-api-node-state/scripts/efm_check_standby.sh
+%attr(-, root, root) /usr/edb/efm-api-node-state/scripts/efm_monitoring.sh
 %attr(0644, root, root) /etc/edb/efm-api-node-state/config.toml
 %attr(-, root, root) /lib/systemd/system/efm-api-node-state.service
 
@@ -50,3 +52,6 @@ exit 0
 %changelog
 * Mon Sep 12 2022 Julien Tachoires <julien.tachoires@enterprisedb.com> - 0.1.0-1
 - Initial release
+
+* Tue Sep 20 2022 Julien Tachoires <julien.tachoires@enterprisedb.com> - 0.2.0-1
+- Release 0.2.0

--- a/scripts/efm_check_primary.sh
+++ b/scripts/efm_check_primary.sh
@@ -3,9 +3,16 @@
 EFM_VERSION=${1:-4.5}
 EFM_CLUSTER_NAME=${2:-main}
 
-IS_PRIMARY=$(/usr/edb/efm-${EFM_VERSION}/bin/efm node-status-json ${EFM_CLUSTER_NAME} | grep '"type":"Primary"' | grep -c '"db":"UP"');
-if [ $IS_PRIMARY -eq "1" ];
-then
+# If EFM's PID file does not exist, this node shouldn't be part of the cluster
+if [ ! -f /var/run/efm-${EFM_VERSION}/${EFM_CLUSTER_NAME}.pid ]; then
+	exit 1;
+fi
+# Test if EFM is still running
+if [ ! ps -p $(cat /var/run/efm-${EFM_VERSION}/${EFM_CLUSTER_NAME}.pid) -o pid= > /dev/null ]; then
+	exit 1;
+fi
+
+if [ -f /var/run/efm-${EFM_VERSION}/efm_trigger_p ]; then
 	exit 0;
-fi;
-exit 1;
+fi
+exit 1

--- a/scripts/efm_check_standby.sh
+++ b/scripts/efm_check_standby.sh
@@ -3,9 +3,16 @@
 EFM_VERSION=${1:-4.5}
 EFM_CLUSTER_NAME=${2:-main}
 
-IS_PRIMARY=$(/usr/edb/efm-${EFM_VERSION}/bin/efm node-status-json ${EFM_CLUSTER_NAME} | grep '"type":"Standby"' | grep -c '"db":"UP"');
-if [ $IS_PRIMARY -eq "1" ];
-then
+# If EFM's PID file does not exist, this node shouldn't be part of the cluster
+if [ ! -f /var/run/efm-${EFM_VERSION}/${EFM_CLUSTER_NAME}.pid ]; then
+	exit 1;
+fi
+# Test if EFM is still running
+if [ ! ps -p $(cat /var/run/efm-${EFM_VERSION}/${EFM_CLUSTER_NAME}.pid) -o pid= > /dev/null ]; then
+	exit 1;
+fi
+
+if [ -f /var/run/efm-${EFM_VERSION}/efm_trigger_s ]; then
 	exit 0;
-fi;
-exit 1;
+fi
+exit 1

--- a/scripts/efm_monitor.sh
+++ b/scripts/efm_monitor.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -eux
+# Script in charge of creating the trigger file if they don't
+# exist.
+
+EFM_VERSION=${1:-"4.4"}
+
+# Checking if the trigger files exist, if they exist, then no
+# need for further verification.
+if [ -f /var/run/efm-${EFM_VERSION}/efm_trigger_p ]; then
+  exit 0
+fi
+if [ -f /var/run/efm-${EFM_VERSION}/efm_trigger_s ]; then
+  exit 0
+fi
+
+# When the trigger file does not exist, we will create it, based
+# on the return of the efm node-status-json command.
+NODE_STATUS=$(/usr/edb/efm-${EFM_VERSION}/bin/efm node-status-json main)
+NODE_TYPE=$(echo $NODE_STATUS | sed -E "s/.*type\":\"([^\"]+)\".*/\1/")
+if [ "${NODE_TYPE}" == "Primary" ]; then
+  /bin/touch /var/run/efm-${EFM_VERSION}/efm_trigger_p
+fi
+if [ "${NODE_TYPE}" == "Standby" ]; then
+  /bin/touch /var/run/efm-${EFM_VERSION}/efm_trigger_s
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ impl EFMAPINodeStateArgs {
     {
         // Basic app information
         let cmd = ClapCommand::new("efm-api-node-state")
-            .version("0.1.0")
+            .version("0.2.0")
             .about("HTTP service and REST API exposing the state of the current EFM node.")
             .author("EDB");
 


### PR DESCRIPTION
Calling directly the efm node-status-json command is slow and response times can grow over than 5 seconds when the system is overloaded.

Finding node state now relies on:
- is EFM running?
- does a specific exists?

Those specific files (/var/run/efm-X.Y/efm_trigger_p for primary, /var/run/efm-X.Y/efm_trigger_s for standby node) are maintained by EFM itself, through its properties: script.load.balancer.attach, script.load.balancer.detach and script.custom.monitor.